### PR TITLE
Fixes deprecated getch

### DIFF
--- a/src/System/IO/HiddenChar/Windows.hs
+++ b/src/System/IO/HiddenChar/Windows.hs
@@ -17,7 +17,7 @@ import           Foreign.C.Types
 
 -- Must import as "safe" in order to prevent FFI call from blocking other threads
 -- https://github.com/rcook/hidden-char/issues/1
-foreign import ccall safe "conio.h getch" c_getch :: IO CInt
+foreign import ccall safe "conio.h _getch" c_getch :: IO CInt
 
 -- | Read a character from the standard input device with buffering and echoing disabled
 -- Hack based on http://stackoverflow.com/questions/2983974/haskell-read-input-character-from-console-immediately-not-after-newline


### PR DESCRIPTION
For more info, see: https://stackoverflow.com/questions/38282624/haskell-foreign-function-interface-with-ghci-in-windows

In short, "getch" is deprecated, and replacing it with "_getch" fixes stuff on windows.
Adding this change allowed the function to work for me on windows.